### PR TITLE
Bug fixes and improvements for E.nav mono

### DIFF
--- a/Development/Core/Mono/v1_0_chip1_CORE.yolol
+++ b/Development/Core/Mono/v1_0_chip1_CORE.yolol
@@ -1,17 +1,17 @@
 h=1000000 e=1000 j="\n\nVel: "
 k=393347889 l=39666 m=100890 n=3395*10^6 o=58319
-p=114430000 q=18945 r=9809.3 s=1599 v=1000
+p=114430000 q=18945 r=9809.3 s=1599
 ox=-9940 oy=4900 oz=0
-:ma="station_hq_imperial_a" :mb="station_capital_imperial_a"
-:mc="station_hq_kingdom_a" :md="station_proving_grounds"
+ma="station_hq_imperial_a" mb="station_capital_imperial_a"
+mc="station_hq_kingdom_a" md="station_proving_grounds" :tm=md
 
-d=:d :d=h-:s :tm=:ma dd=(:d-d)/8
-x=(:a^2+k-:c^2)/l y=-(:a^2+n-o*x -:d^2)/m z=-(:a^2+p-q*x-r*-y-:b^2)/s
-a=:a :a=h-:s :tm=:mb da=(:a-a)/8 :b+=6*db :c+=4*dc :d+=2*dd
+cd=dm dm=h-:s :tm=ma d=dm+(dm-cd)*7/8
+x=(a^2+k-c^2)/l y=-(a^2+n-o*x-d^2)/m z=-(a^2+p-q*x-r*-y-b^2)/s
+ca=am am=h-:s :tm=mb a=am+(am-ca)*13/8
 x=x+ox y=y+oy z=z+oz
-b=:b :b=h-:s :tm=:mc db=(:b-b)/8
+cb=bm bm=h-:s :tm=mc b=bm+(bm-cb)*11/8
 i=((x-xo)^2+(y-yo)^2+(z-zo)^2)^0.5/1.6 xo=x yo=y zo=z
-c=:c :c=h-:s :tm=:md dc=(:c-c)/8
+cc=cm cm=h-:s :tm=md c=cm+(cm-cc)*9/8
 :pos="\nX: "+x/e*e+"\nY: "+y/e*e+"\nZ: "+z/e*e+j+i/e*e+"m/s" goto8
 
 


### PR DESCRIPTION
- removed unused var "v"
- no longer overwrites predictive corrections before they're used (increases accuracy, since now actually using predictions)
- removed unnessesary globals (saves the whole memory chip)
- multiply measurement delta's before dividing (extra ~1dp of accuracy)
- uses seperate storage for measured value (#m), cached value (c#) & predicted value (#) [where #=a|b|c|d]
    - Previously, the predictions overwrote the measured value, leading to an incorrect delta measurement in the next loop
- Now predicts position value forward to line 15 (shows current position instead of position 6 ticks ago) ("what would this transmitter measure if pinged just before we outputted position)
    -optionally replaces forward prediction values (7,13,11 & 9) on lines 8, 10, 12 & 14 with 1, 7, 5 & 3 to predict position on line 9 & include the 6 tick display latency.
- Moved the predictions to their respective lines (gives more space each line & allows for further space saving)
- Removed storage variables for delta calculations. These are only used once so the variable is not needed.
- added :tm=md on line 6 so that the system works on the first loop

Further improvements could include error detection & message. Error cases:
 - Out of range (ship not in the "ISANv1 bubble")
 - Transmitter not loaded (they just cease to exist if someone isn't loading them)

Overview of var renames:
Old | new
-|-
``:a`` |  ``ma`` (measurement) / ``a`` (corrected)
``:b`` |  ``mb`` (measurement) / ``b`` (corrected)
``:c`` |  ``mc`` (measurement) / ``c`` (corrected)
``:d`` |  ``md`` (measurement) / ``d`` (corrected)
``a`` | ``ca`` ("cache a") (doesn't need to be global)
``b`` | ``cb`` ("cache b") (doesn't need to be global)
``c`` | ``cc`` ("cache c") (doesn't need to be global)
``d`` | ``cd`` ("cache d") (doesn't need to be global)
``:ma`` | ``ma`` (doesn't need to be global)
``:mb`` | ``mb`` (doesn't need to be global)
``:mc`` | ``mc`` (doesn't need to be global)
``:md`` | ``md`` (doesn't need to be global)
``da`` | removed
``db`` | removed
``dc`` | removed
``dd`` | removed



